### PR TITLE
Fix several issues when building DDS on Windows with MinGW

### DIFF
--- a/dds/api/headers/dds/dds_debug.h
+++ b/dds/api/headers/dds/dds_debug.h
@@ -26,6 +26,7 @@
 #define __dds_debug_h_
 
 #include "dds/dds_error.h"
+#include "dds/dds_aux.h"
 #ifdef XTYPES_USED
 #include "dds/dds_xtypes.h"
 #endif

--- a/dds/apps/chat/main.c
+++ b/dds/apps/chat/main.c
@@ -17,7 +17,9 @@
 #include <string.h>
 #include <ctype.h>
 #include <unistd.h>
+#ifndef _WIN32
 #include <poll.h>
+#endif
 #include "thread.h"
 #include "libx.h"
 #include "tty.h"

--- a/dds/src/bgns/bgns.c
+++ b/dds/src/bgns/bgns.c
@@ -17,7 +17,7 @@
 #include <stdint.h>
 #ifndef _WIN32
 #	include <arpa/inet.h>
-#endif //_WIN32
+#endif /* _WIN32 */
 #include "log.h"
 #include "list.h"
 #include "error.h"

--- a/dds/src/bgns/bgns.c
+++ b/dds/src/bgns/bgns.c
@@ -15,7 +15,9 @@
 /* bgns.c -- Implements the Background Notification Server functionality. */
 
 #include <stdint.h>
-#include <arpa/inet.h>
+#ifndef _WIN32
+#	include <arpa/inet.h>
+#endif //_WIN32
 #include "log.h"
 #include "list.h"
 #include "error.h"

--- a/dds/src/co/fnmatch.c
+++ b/dds/src/co/fnmatch.c
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 1989, 1993, 1994
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * This code is derived from software contributed to Berkeley by
+ * Guido van Rossum.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * From FreeBSD fnmatch.c 1.11
+ * $Id: fnmatch.c,v 1.3 1997/08/19 02:34:30 jdp Exp $
+ */
+
+#if defined(LIBC_SCCS) && !defined(lint)
+static char sccsid[] = "@(#)fnmatch.c	8.2 (Berkeley) 4/16/94";
+#endif /* LIBC_SCCS and not lint */
+
+/*
+ * Function fnmatch() as specified in POSIX 1003.2-1992, section B.6.
+ * Compares a filename or pathname to a pattern.
+ */
+
+#include <ctype.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "fnmatch.h"
+
+#define	EOS	'\0'
+
+static const char *rangematch(const char *, char, int);
+
+int
+fnmatch(const char *pattern, const char *string, int flags)
+{
+	const char *stringstart;
+	char c, test;
+
+	for (stringstart = string;;)
+		switch (c = *pattern++) {
+		case EOS:
+			if ((flags & FNM_LEADING_DIR) && *string == '/')
+				return (0);
+			return (*string == EOS ? 0 : FNM_NOMATCH);
+		case '?':
+			if (*string == EOS)
+				return (FNM_NOMATCH);
+			if (*string == '/' && (flags & FNM_PATHNAME))
+				return (FNM_NOMATCH);
+			if (*string == '.' && (flags & FNM_PERIOD) &&
+			    (string == stringstart ||
+			    ((flags & FNM_PATHNAME) && *(string - 1) == '/')))
+				return (FNM_NOMATCH);
+			++string;
+			break;
+		case '*':
+			c = *pattern;
+			/* Collapse multiple stars. */
+			while (c == '*')
+				c = *++pattern;
+
+			if (*string == '.' && (flags & FNM_PERIOD) &&
+			    (string == stringstart ||
+			    ((flags & FNM_PATHNAME) && *(string - 1) == '/')))
+				return (FNM_NOMATCH);
+
+			/* Optimize for pattern with * at end or before /. */
+			if (c == EOS)
+				if (flags & FNM_PATHNAME)
+					return ((flags & FNM_LEADING_DIR) ||
+					    strchr(string, '/') == NULL ?
+					    0 : FNM_NOMATCH);
+				else
+					return (0);
+			else if (c == '/' && flags & FNM_PATHNAME) {
+				if ((string = strchr(string, '/')) == NULL)
+					return (FNM_NOMATCH);
+				break;
+			}
+
+			/* General case, use recursion. */
+			while ((test = *string) != EOS) {
+				if (!fnmatch(pattern, string, flags & ~FNM_PERIOD))
+					return (0);
+				if (test == '/' && flags & FNM_PATHNAME)
+					break;
+				++string;
+			}
+			return (FNM_NOMATCH);
+		case '[':
+			if (*string == EOS)
+				return (FNM_NOMATCH);
+			if (*string == '/' && flags & FNM_PATHNAME)
+				return (FNM_NOMATCH);
+			if ((pattern =
+			    rangematch(pattern, *string, flags)) == NULL)
+				return (FNM_NOMATCH);
+			++string;
+			break;
+		case '\\':
+			if (!(flags & FNM_NOESCAPE)) {
+				if ((c = *pattern++) == EOS) {
+					c = '\\';
+					--pattern;
+				}
+			}
+			/* FALLTHROUGH */
+		default:
+			if (c == *string)
+				;
+			else if ((flags & FNM_CASEFOLD) &&
+				 (tolower((unsigned char)c) ==
+				  tolower((unsigned char)*string)))
+				;
+			else if ((flags & FNM_PREFIX_DIRS) && *string == EOS &&
+			     ((c == '/' && string != stringstart) ||
+			     (string == stringstart+1 && *stringstart == '/')))
+				return (0);
+			else
+				return (FNM_NOMATCH);
+			string++;
+			break;
+		}
+	/* NOTREACHED */
+}
+
+static const char *
+rangematch(const char *pattern, char test, int flags)
+{
+	int negate, ok;
+	char c, c2;
+
+	/*
+	 * A bracket expression starting with an unquoted circumflex
+	 * character produces unspecified results (IEEE 1003.2-1992,
+	 * 3.13.2).  This implementation treats it like '!', for
+	 * consistency with the regular expression syntax.
+	 * J.T. Conklin (conklin@ngai.kaleida.com)
+	 */
+	if ( (negate = (*pattern == '!' || *pattern == '^')) )
+		++pattern;
+
+	if (flags & FNM_CASEFOLD)
+		test = tolower((unsigned char)test);
+
+	for (ok = 0; (c = *pattern++) != ']';) {
+		if (c == '\\' && !(flags & FNM_NOESCAPE))
+			c = *pattern++;
+		if (c == EOS)
+			return (NULL);
+
+		if (flags & FNM_CASEFOLD)
+			c = tolower((unsigned char)c);
+
+		if (*pattern == '-'
+		    && (c2 = *(pattern+1)) != EOS && c2 != ']') {
+			pattern += 2;
+			if (c2 == '\\' && !(flags & FNM_NOESCAPE))
+				c2 = *pattern++;
+			if (c2 == EOS)
+				return (NULL);
+
+			if (flags & FNM_CASEFOLD)
+				c2 = tolower((unsigned char)c2);
+
+			if ((unsigned char)c <= (unsigned char)test &&
+			    (unsigned char)test <= (unsigned char)c2)
+				ok = 1;
+		} else if (c == test)
+			ok = 1;
+	}
+	return (ok == negate ? NULL : pattern);
+}

--- a/dds/src/co/libx.c
+++ b/dds/src/co/libx.c
@@ -20,6 +20,7 @@
 #include <stdarg.h>
 #include <string.h>
 #include "libx.h"
+#include "dds/dds_error.h"
 
 /* astrcmp -- Compare two strings for equality but do it case independent. */
 
@@ -62,7 +63,7 @@ int astrncmp (const char *s1, const char *s2, size_t n)
 }
 
 
-void fatal (const char *fmt, ...)
+DDS_EXPORT void fatal (const char *fmt, ...)
 {
 	va_list	arg;
 

--- a/dds/src/co/sock.c
+++ b/dds/src/co/sock.c
@@ -352,7 +352,7 @@ int sock_fd_event_socket (SOCKET s, short events, int set)
 
 /* sock_fd_udata_socket -- Update the notified user data on a socket. */
 
-int sock_fd_udata_socket (SOCKET s, void *udata)
+void sock_fd_udata_socket (SOCKET s, void *udata)
 {
 	unsigned	i;
 	SockSocket_t	*sp;
@@ -364,7 +364,6 @@ int sock_fd_udata_socket (SOCKET s, void *udata)
 			break;
 		}
 	lock_release (sock_lock);
-	return (0);
 }
 
 /* sock_fd_schedule -- Schedule all pending event handlers. */

--- a/dds/src/co/sock.c
+++ b/dds/src/co/sock.c
@@ -24,6 +24,7 @@
 #include <unistd.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
+#include <sys/socket.h>
 #ifdef __linux__
 #include <sys/epoll.h>
 #define	EPOLL_USED
@@ -45,7 +46,6 @@
 #include "debug.h"
 #include "sock.h"
 #include <sys/types.h>
-#include <sys/socket.h>
 
 static int n_ready;
 static lock_t sock_lock;

--- a/dds/src/co/thread.c
+++ b/dds/src/co/thread.c
@@ -469,6 +469,19 @@ void rcl_done (void *p) {}
 #define ev_signal(ev)		SetEvent (ev)
 #define ev_destroy(ev)		CloseHandle (ev)
 
+int emulate_pthread_mutex_lock(volatile lock_t *mx) 
+{ 
+   if (*mx == NULL) /* Static Initializer */ 
+   { 
+      lock_t p = CreateMutex (NULL, 0, /*s*/NULL); 
+      if ( InterlockedCompareExchangePointer( (PVOID *)mx, (PVOID)p, NULL) != NULL ) 
+      { 
+         CloseHandle(p); 
+      } 
+   } 
+   return WaitForSingleObject (*mx, INFINITE) == WAIT_FAILED; 
+}
+
 static lock_t		rclock;
 
 int dds_cond_broadcast (cond_t *cv)

--- a/dds/src/co/thread.c
+++ b/dds/src/co/thread.c
@@ -451,10 +451,10 @@ void rcl_done (void *p)
 }
 
 #else
-
+#ifndef _WIN32
 void rcl_access (void *p) {}
 void rcl_done (void *p) {}
-
+#endif /* _WIN32 */
 #endif /* PTHREADS_USED */
 
 #ifdef _WIN32

--- a/dds/src/co/tty.c
+++ b/dds/src/co/tty.c
@@ -19,10 +19,10 @@
 #ifndef _WIN32
 #include <unistd.h>
 #include <termios.h>
+#include <poll.h>
 #endif
 #include <stdarg.h>
 #include <stdint.h>
-#include <poll.h>
 #include "libx.h"
 #include "dds/dds_aux.h"
 #include "tty.h"

--- a/dds/src/co/win.c
+++ b/dds/src/co/win.c
@@ -24,28 +24,6 @@
 
 #ifdef _WIN32
 
-void usleep (long usec)
-{
-	LARGE_INTEGER	lFrequency;
-	LARGE_INTEGER	lEndTime;
-	LARGE_INTEGER	lCurTime;
-
-	if (usec >= 1000) {
-		Sleep (usec / 1000);	/* Don't bother with us accuracy. */
-		return;
-	}
-	QueryPerformanceFrequency (&lFrequency);
-	if (lFrequency.QuadPart) {
-		QueryPerformanceCounter (&lEndTime);
-		lEndTime.QuadPart += (LONGLONG) usec * lFrequency.QuadPart / 1000000;
-		do {
-			QueryPerformanceCounter (&lCurTime);
-			Sleep(0);
-		}
-		while (lCurTime.QuadPart < lEndTime.QuadPart);
-	}
-}
-
 static LARGE_INTEGER get_filetime_offset (void)
 {
 	SYSTEMTIME	s;
@@ -107,6 +85,29 @@ int clock_gettime (int X, struct timespec *tv)
 }
 
 #if _MSC_VER /* Only available on MS Visual Studio */
+
+void usleep (long usec)
+{
+	LARGE_INTEGER	lFrequency;
+	LARGE_INTEGER	lEndTime;
+	LARGE_INTEGER	lCurTime;
+
+	if (usec >= 1000) {
+		Sleep (usec / 1000);	/* Don't bother with us accuracy. */
+		return;
+	}
+	QueryPerformanceFrequency (&lFrequency);
+	if (lFrequency.QuadPart) {
+		QueryPerformanceCounter (&lEndTime);
+		lEndTime.QuadPart += (LONGLONG) usec * lFrequency.QuadPart / 1000000;
+		do {
+			QueryPerformanceCounter (&lCurTime);
+			Sleep(0);
+		}
+		while (lCurTime.QuadPart < lEndTime.QuadPart);
+	}
+}
+
 int gettimeofday (struct timeval *tv, struct timezone *tz)
 {
 	struct timespec ts;

--- a/dds/src/co/win.c
+++ b/dds/src/co/win.c
@@ -106,6 +106,7 @@ int clock_gettime (int X, struct timespec *tv)
 	return (0);
 }
 
+#if _MSC_VER /* Only available on MS Visual Studio */
 int gettimeofday (struct timeval *tv, struct timezone *tz)
 {
 	struct timespec ts;
@@ -127,5 +128,6 @@ int gettimeofday (struct timeval *tv, struct timezone *tz)
 	}
 	return (0);
 }
+#endif /* _MSC_VER */
 
 #endif /* _WIN32 */

--- a/dds/src/dbg/debug.c
+++ b/dds/src/dbg/debug.c
@@ -1869,10 +1869,6 @@ void debug_command (const char *buf)
 		dbg_printf ("?%s\r\n", cmd);
 }
 
-#ifndef MSG_NOSIGNAL
-#define MSG_NOSIGNAL 0
-#endif
-
 static void debug_session_destroy (DebugSession_t *sp)
 {
 	static const char	close_msg [] = "TDDS closing connection!\r\n";

--- a/dds/src/dynip/di_windows.c
+++ b/dds/src/dynip/di_windows.c
@@ -16,6 +16,7 @@
 
 #include <stdio.h>
 #include "win.h"
+#include "timer.h"
 #include "Ws2IpDef.h"
 #include "Ws2tcpip.h"
 #include "dds/dds_error.h"
@@ -62,13 +63,13 @@ static void di_event (intptr_t user)
 
 	if (ipv4.fct) {
 		*ipv4.n = sys_own_ipv4_addr (ipv4.ipa, ipv4.max,
-					     ipv4.min_scope, ipv4.max_scope);
+					     ipv4.min_scope, ipv4.max_scope, 0);
 		(*ipv4.fct)();
 	}
 #ifdef DDS_IPV6
 	if (ipv6.fct) {
 		*ipv6.n = sys_own_ipv6_addr (ipv6.ipa, ipv6.max,
-					     ipv6.min_scope, ipv6.max_scope);
+					     ipv6.min_scope, ipv6.max_scope, 0);
 		(*ipv6.fct)();
 	}
 #endif
@@ -124,7 +125,7 @@ int di_sys_detach (unsigned family)
 	else
 		return (DDS_RETCODE_BAD_PARAMETER);
 
-	if (!ipv4_fct
+	if (!ipv4.fct
 #ifdef DDS_IPV6
 	              && !ipv6.fct
 #endif
@@ -146,6 +147,6 @@ void di_sys_final (void)
 
 void di_sys_check (void)
 {
-	di_event ();
+	di_event (0);
 }
 

--- a/dds/src/include/debug.h
+++ b/dds/src/include/debug.h
@@ -21,6 +21,10 @@
 #include "rtps.h"
 #include "sock.h"
 
+#ifndef MSG_NOSIGNAL
+#define MSG_NOSIGNAL 0
+#endif
+
 /* Some utility functions: */
 
 void dbg_print_uclist (unsigned nchars, const unsigned char *cp, int hex);

--- a/dds/src/include/error.h
+++ b/dds/src/include/error.h
@@ -19,6 +19,7 @@
 
 #include <stdio.h>
 #include <stdint.h>
+#include "dds/dds_error.h"
 #include "sock.h"
 #include "sys.h"
 
@@ -126,7 +127,7 @@ unsigned log_logged (unsigned id, unsigned level);
 /* Return the logging status of the given id/level. */
 
 
-void dbg_printf (const char *fmt, ...)
+DDS_EXPORT void dbg_printf (const char *fmt, ...)
 	__attribute__((format(printf, 1, 2)));
 
 /* Display a debug shell request or response message. */
@@ -172,7 +173,7 @@ void err_printf (const char *fmt, ...)
 #ifdef _WIN32
 __declspec(noreturn)
 #endif
-void fatal_printf (const char *fmt, ...)
+DDS_EXPORT void fatal_printf (const char *fmt, ...)
 	__attribute__((noreturn, format(printf, 1, 2)));
 
 /* Non-recoverable error message. */

--- a/dds/src/include/thread.h
+++ b/dds/src/include/thread.h
@@ -46,18 +46,7 @@ void thread_init (void);
 #define	thread_wait(t,st)	WaitForSingleObject(t, INFINITE)
 #define thread_return(p)	_endthread()
 
-int emulate_pthread_mutex_lock(volatile lock_t *mx)
-{
-	if (*mx == NULL) /* Static Initializer */
-	{
-		lock_t p = CreateMutex (NULL, 0, /*s*/NULL);
-		if ( InterlockedCompareExchangePointer( (PVOID *)mx, (PVOID)p, NULL) != NULL )
-		{
-			CloseHandle(p);
-		}
-	}
-	return WaitForSingleObject (*mx, INFINITE) == WAIT_FAILED;
-}
+int emulate_pthread_mutex_lock(volatile lock_t *mx);
 
 /* Condition variables can not be defined in a simple manner on Windows since
    they were only implemented from Windows Vista onwards and are thus not avail-

--- a/dds/src/include/tty.h
+++ b/dds/src/include/tty.h
@@ -17,12 +17,13 @@
 #ifndef __tty_h_
 #define	__tty_h_
 
+#include "dds/dds_error.h"
 #include "sock.h"
 
-extern HANDLE tty_stdin;
+DDS_EXPORT extern HANDLE tty_stdin;
 extern unsigned tty_width, tty_height;
 
-void tty_init (void);
+DDS_EXPORT void tty_init (void);
 
 /* Initialize the terminal.  Sets Raw mode and installs an exit handler to
    restore the mode on exit. */
@@ -146,7 +147,7 @@ void tty_restore_cursor_attr (void);
 /* Restore the cursor position and attributes. */
 
 
-void tty_input (HANDLE fd, short events, void *udata);
+DDS_EXPORT void tty_input (HANDLE fd, short events, void *udata);
 
 /* Utility function to queue characters in an input buffer. */
 
@@ -155,7 +156,7 @@ int tty_getch (void);
 /* Attempts to read a single character from the input buffer.  Blocks until
    a character is available. */
 
-int tty_gets (size_t nchars, char buf [], int number, int echo);
+DDS_EXPORT int tty_gets (size_t nchars, char buf [], int number, int echo);
 
 /* Attempts to read a complete line from the input buffer.  Blocks until an
    end-of-line is entered.  If the number argument is set, only numeric

--- a/dds/src/include/win.h
+++ b/dds/src/include/win.h
@@ -72,7 +72,6 @@ int gettimeofday (struct timeval *tv, struct timezone *tz);
 #define INLINE
 
 #define snprintf	sprintf_s
-#define vsnprintf(d,dsize,fmt,arg)	vsnprintf_s(d,dsize,dsize-1,fmt,arg)
 #define strncpy(d,s,n)	strcpy_s(d,n,s)
 #define sscanf		sscanf_s
 #define isblank(c)	((c)==' '||(c)=='\t')
@@ -81,9 +80,10 @@ int gettimeofday (struct timeval *tv, struct timezone *tz);
 #define PRId64	"lld"
 #define PRIu64	"llu"
 
-#if _MSC_VER //Only available on MS Visual Studio
+#if _MSC_VER /* Only available on MS Visual Studio */
+#	define vsnprintf(d,dsize,fmt,arg)	vsnprintf_s(d,dsize,dsize-1,fmt,arg)
 #	define strtold	strtod
-#endif //_MSC_VER
+#endif /* _MSC_VER */
 
 #endif
 

--- a/dds/src/include/win.h
+++ b/dds/src/include/win.h
@@ -39,11 +39,11 @@ struct timezone {
 	int	tz_minuteswest; /* Minutes W of Greenwich. */
 	int	tz_dsttime;     /* Type of dst correction. */
 };
+void usleep (long usec);
 #else
 #	include <time.h>
+#	include <unistd.h>
 #endif //_MSC_VER
-
-void usleep (long usec);
 
 #define CLOCK_REALTIME	0
 #define CLOCK_MONOTONIC	1

--- a/dds/src/include/win.h
+++ b/dds/src/include/win.h
@@ -27,27 +27,29 @@
 #include <windows.h>
 #include <process.h>
 #include <winsock2.h>
-#if !defined (_M_X64) && !defined (_M_IA64)
-#include "vld.h"
-#endif
+#if _MSC_VER //Only available on MS Visual Studio
+#	if !defined (_M_X64) && !defined (_M_IA64)
+#		include "vld.h"
+#	endif
+struct timespec {
+	time_t	tv_sec;
+	long	tv_nsec;
+};
+struct timezone {
+	int	tz_minuteswest; /* Minutes W of Greenwich. */
+	int	tz_dsttime;     /* Type of dst correction. */
+};
+#else
+#	include <time.h>
+#endif //_MSC_VER
 
 void usleep (long usec);
 
 #define CLOCK_REALTIME	0
 #define CLOCK_MONOTONIC	1
 
-struct timespec {
-	time_t	tv_sec;
-	long	tv_nsec;
-};
-
 int clock_gettime (int X, struct timespec *tv);
 
-struct timezone {
-	int	tz_minuteswest; /* Minutes W of Greenwich. */
-	int	tz_dsttime;     /* Type of dst correction. */
-};
- 
 int gettimeofday (struct timeval *tv, struct timezone *tz);
 
 #ifndef POLLRDNORM	/* Pre-Vista? No WSAPoll(). */
@@ -79,7 +81,9 @@ int gettimeofday (struct timeval *tv, struct timezone *tz);
 #define PRId64	"lld"
 #define PRIu64	"llu"
 
-#define strtold	strtod
+#if _MSC_VER //Only available on MS Visual Studio
+#	define strtold	strtod
+#endif //_MSC_VER
 
 #endif
 

--- a/dds/src/include/windows/fnmatch.h
+++ b/dds/src/include/windows/fnmatch.h
@@ -1,0 +1,58 @@
+/*-
+ * Copyright (c) 1992, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)fnmatch.h	8.1 (Berkeley) 6/2/93
+ *
+ * From FreeBSD fnmatch.h 1.7
+ * $Id: fnmatch.h,v 1.4 2001/10/04 02:46:21 jdp Exp $
+ */
+
+#ifndef	_FNMATCH_H_
+#define	_FNMATCH_H_
+
+#define	FNM_NOMATCH	1	/* Match failed. */
+
+#define	FNM_NOESCAPE	0x01	/* Disable backslash escaping. */
+#define	FNM_PATHNAME	0x02	/* Slash must be matched by slash. */
+#define	FNM_PERIOD	0x04	/* Period must be matched by period. */
+#define	FNM_LEADING_DIR	0x08	/* Ignore /<tail> after Imatch. */
+#define	FNM_CASEFOLD	0x10	/* Case insensitive search. */
+#define FNM_PREFIX_DIRS	0x20	/* Directory prefixes of pattern match too. */
+
+/* Make this compile successfully with "gcc -traditional" */
+#ifndef __STDC__
+#define const	/* empty */
+#endif
+
+int	 fnmatch(const char *, const char *, int);
+
+#endif /* !_FNMATCH_H_ */

--- a/dds/test/api/ta_data.c
+++ b/dds/test/api/ta_data.c
@@ -13,7 +13,9 @@
  */
 
 #include <pthread.h>
+#ifndef _WIN32
 #include <arpa/inet.h>
+#endif
 #include "test.h"
 #include "ta_type.h"
 #include "ta_disc.h"

--- a/dds/test/api/ta_disc.c
+++ b/dds/test/api/ta_disc.c
@@ -12,7 +12,9 @@
  * See LICENSE file for more details.
  */
 
+#ifndef _WIN32
 #include <arpa/inet.h>
+#endif
 #include "test.h"
 #include "ta_part.h"
 #include "ta_disc.h"

--- a/dds/test/api/ta_part.c
+++ b/dds/test/api/ta_part.c
@@ -12,7 +12,9 @@
  * See LICENSE file for more details.
  */
 
+#ifndef _WIN32
 #include <arpa/inet.h>
+#endif
 #include "test.h"
 #include "ta_data.h"
 #include "ta_part.h"


### PR DESCRIPTION
All these patches provide the necessary fixes in order to build DDS on Windows using MinGW 4.9.2.

Please notice that we are not including any fixes for the original Makefiles included in the Qeo project, as we work with CMake, and also some of the tests won't build (or even work) correctly yet.

Also we don't provide any fixes for the upper layers of Qeo, but this should be a good foundation on which further work can be made in order to achieve full Windows compatibility.
